### PR TITLE
Upgrade to .NET 8, update SecureRandom to v2, and harden key agreement

### DIFF
--- a/Curve25519.NetCore.Examples/Curve25519.NetCore.Examples.csproj
+++ b/Curve25519.NetCore.Examples/Curve25519.NetCore.Examples.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Curve25519.NetCore.Examples/Program.cs
+++ b/Curve25519.NetCore.Examples/Program.cs
@@ -1,24 +1,11 @@
-﻿using System;
-using System.Linq;
+var curve25519 = new Curve25519.NetCore.Curve25519();
+var alicePrivate = curve25519.CreateRandomPrivateKey();
+var alicePublic = curve25519.GetPublicKey(alicePrivate);
 
-namespace Curve25519.NetCore.Examples
-{
-    class Program
-    {
-        static void Main(string[] args)
-        {
-            var curve25519 = new Curve25519();
-            var alicePrivate = curve25519.CreateRandomPrivateKey();
-            var alicePublic = curve25519.GetPublicKey(alicePrivate);
+var bobPrivate = curve25519.CreateRandomPrivateKey();
+var bobPublic = curve25519.GetPublicKey(bobPrivate);
 
-            var bobPrivate = curve25519.CreateRandomPrivateKey();
-            var bobPublic = curve25519.GetPublicKey(bobPrivate);
+var aliceShared = curve25519.GetSharedSecret(alicePrivate, bobPublic);
+var bobShared = curve25519.GetSharedSecret(bobPrivate, alicePublic);
 
-            var aliceShared = curve25519.GetSharedSecret(alicePrivate, bobPublic);
-            var bobShared = curve25519.GetSharedSecret(bobPrivate, alicePublic);
-            var equal = aliceShared.SequenceEqual(bobShared);
-
-            return;
-        }
-    }
-}
+Console.WriteLine($"Shared secrets match: {aliceShared.SequenceEqual(bobShared)}");

--- a/Curve25519.NetCore/Curve25519.NetCore.csproj
+++ b/Curve25519.NetCore/Curve25519.NetCore.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Authors>Timothy D Meadows II</Authors>
     <Description>An elliptic curve offering 128 bits of security and designed for use with the elliptic curve Diffie–Hellman (ECDH) key agreement scheme. It is one of the fastest ECC curves and is not covered by any known patents.</Description>
@@ -12,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SecureRandom.NetCore" Version="1.0.0" />
+    <PackageReference Include="SecureRandom.NetCore" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Curve25519.NetCore/Curve25519.cs
+++ b/Curve25519.NetCore/Curve25519.cs
@@ -14,10 +14,11 @@
  */
 
 using System;
+using System.Security.Cryptography;
 
 namespace Curve25519.NetCore
 {
-    public class Curve25519
+    public sealed class Curve25519
     {
         /// <summary>
         /// Smallest multiple of the order that's >= 2^255
@@ -60,15 +61,35 @@ namespace Curve25519.NetCore
 
         /********* KEY AGREEMENT *********/
 
+        private static void ValidatePrivateKey(byte[] privateKey)
+        {
+            ArgumentNullException.ThrowIfNull(privateKey);
+            if (privateKey.Length != KeySize)
+            {
+                throw new ArgumentException($"Private key must be {KeySize} bytes long (but was {privateKey.Length} bytes long).", nameof(privateKey));
+            }
+        }
+
+        private static void ValidatePublicKey(byte[] publicKey)
+        {
+            ArgumentNullException.ThrowIfNull(publicKey);
+            if (publicKey.Length != KeySize)
+            {
+                throw new ArgumentException($"Public key must be {KeySize} bytes long (but was {publicKey.Length} bytes long).", nameof(publicKey));
+            }
+        }
+
         /// <summary>
         /// Private key clamping (inline, for performance)
         /// </summary>
         /// <param name="key">[out] 32 random bytes</param>
         public void ClampPrivateKeyInline(byte[] key)
         {
-            if (key == null) throw new ArgumentNullException(nameof(key));
-            if (key.Length != 32) throw new ArgumentException(
-                $"key must be 32 bytes long (but was {key.Length} bytes long)");
+            ArgumentNullException.ThrowIfNull(key);
+            if (key.Length != KeySize)
+            {
+                throw new ArgumentException($"key must be {KeySize} bytes long (but was {key.Length} bytes long).", nameof(key));
+            }
 
             key[31] &= 0x7F;
             key[31] |= 0x40;
@@ -81,12 +102,14 @@ namespace Curve25519.NetCore
         /// <param name="rawKey">[out] 32 random bytes</param>
         public byte[] ClampPrivateKey(byte[] rawKey)
         {
-            if (rawKey == null) throw new ArgumentNullException(nameof(rawKey));
-            if (rawKey.Length != 32) throw new ArgumentException(
-                $"rawKey must be 32 bytes long (but was {rawKey.Length} bytes long)", nameof(rawKey));
+            ArgumentNullException.ThrowIfNull(rawKey);
+            if (rawKey.Length != KeySize)
+            {
+                throw new ArgumentException($"rawKey must be {KeySize} bytes long (but was {rawKey.Length} bytes long).", nameof(rawKey));
+            }
 
-            var res = new byte[32];
-            Array.Copy(rawKey, res, 32);
+            var res = new byte[KeySize];
+            Array.Copy(rawKey, res, KeySize);
 
             res[31] &= 0x7F;
             res[31] |= 0x40;
@@ -101,8 +124,8 @@ namespace Curve25519.NetCore
         /// <returns>32 random bytes that are clamped to a suitable private key</returns>
         public byte[] CreateRandomPrivateKey()
         {
-            var privateKey = new byte[32];
-            using var rng = new SecureRandom.NetCore.SecureRandom(20);
+            var privateKey = new byte[KeySize];
+            using var rng = new SecureRandom.NetCore.SecureRandom();
             rng.NextBytes(privateKey);
 
             ClampPrivateKeyInline(privateKey);
@@ -115,7 +138,9 @@ namespace Curve25519.NetCore
         /// <param name="privateKey">private key (must use ClampPrivateKey first!)</param>
         public byte[] GetPublicKey(byte[] privateKey)
         {
-            var publicKey = new byte[32];
+            ValidatePrivateKey(privateKey);
+
+            var publicKey = new byte[KeySize];
 
             Core(publicKey, null, privateKey, null);
             return publicKey;
@@ -127,8 +152,10 @@ namespace Curve25519.NetCore
         /// <param name="privateKey">private key (must use ClampPrivateKey first!)</param>
         public byte[] GetSigningKey(byte[] privateKey)
         {
-            var signingKey = new byte[32];
-            var publicKey = new byte[32];
+            ValidatePrivateKey(privateKey);
+
+            var signingKey = new byte[KeySize];
+            var publicKey = new byte[KeySize];
 
             Core(publicKey, signingKey, privateKey, null);
             return signingKey;
@@ -142,9 +169,19 @@ namespace Curve25519.NetCore
         /// <returns>shared secret (needs hashing before use)</returns>
         public byte[] GetSharedSecret(byte[] privateKey, byte[] peerPublicKey)
         {
-            var sharedSecret = new byte[32];
+            ValidatePrivateKey(privateKey);
+            ValidatePublicKey(peerPublicKey);
+
+            var sharedSecret = new byte[KeySize];
 
             Core(sharedSecret, null, privateKey, peerPublicKey);
+
+            Span<byte> allZeros = stackalloc byte[KeySize];
+            if (CryptographicOperations.FixedTimeEquals(sharedSecret, allZeros))
+            {
+                throw new CryptographicException("Derived shared secret is all zeros. Rejecting per RFC 7748 guidance.");
+            }
+
             return sharedSecret;
         }
 
@@ -796,7 +833,7 @@ namespace Curve25519.NetCore
         /// <summary>
         /// P = kG   and  s = sign(P)/k
         /// </summary>
-        private void Core(byte[] publicKey, byte[] signingKey, byte[] privateKey, byte[] peerPublicKey)
+        private void Core(byte[] publicKey, byte[]? signingKey, byte[] privateKey, byte[]? peerPublicKey)
         {
             if (publicKey == null) throw new ArgumentNullException(nameof(publicKey));
             if (publicKey.Length != 32) throw new ArgumentException(

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Curve25519.NetCore
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![nuget](https://img.shields.io/nuget/v/Curve25519.NetCore.svg)](https://www.nuget.org/packages/Curve25519.NetCore/)
 
-An elliptic curve offering 128 bits of security and designed for use with the elliptic curve Diffie–Hellman (ECDH) key agreement scheme. It is one of the fastest ECC curves and is not covered by any known patents. Depends on [SecureRandom.NetCore](https://github.com/TimothyMeadows/SecureRandom.NetCore)
+An elliptic curve offering 128 bits of security and designed for use with the elliptic curve Diffie–Hellman (ECDH) key agreement scheme. It is one of the fastest ECC curves and is not covered by any known patents. Depends on [SecureRandom.NetCore](https://github.com/TimothyMeadows/SecureRandom.NetCore) (v2.x).
 
 # Install
 
@@ -34,3 +34,14 @@ var aliceShared = curve25519.GetSharedSecret(alicePrivate, bobPublic);
 var bobShared = curve25519.GetSharedSecret(bobPrivate, alicePublic);
 var equal = aliceShared.SequenceEqual(bobShared);
 ```
+
+
+## Framework support
+
+This project now targets **.NET 8**.
+
+## Security notes
+
+- Private and public key lengths are validated before cryptographic operations.
+- Shared secrets that evaluate to all-zero are rejected according to [RFC 7748, Section 6.1](https://www.rfc-editor.org/rfc/rfc7748#section-6.1).
+- Generated private keys are clamped before use.


### PR DESCRIPTION
### Motivation
- Move the project to current LTS framework and modern C# defaults by targeting `net8.0` and enabling nullable reference types and implicit usings.
- Update the `SecureRandom.NetCore` dependency to the latest `2.0.0` release and modernize random key generation usage.
- Improve security posture by adding input validation and following RFC 7748 guidance to reject low-order/all-zero shared secrets.

### Description
- Updated project files to target `net8.0` and enabled `<Nullable>enable</Nullable>` and `<ImplicitUsings>enable</ImplicitUsings>` in both the library and example projects, and updated the package reference to `SecureRandom.NetCore` version `2.0.0` (`Curve25519.NetCore.csproj`, examples project file).
- Modernized example to top-level statements and simplified output to print the shared-secret equality result (`Curve25519.NetCore.Examples/Program.cs`).
- Hardened `Curve25519` library by adding `ValidatePrivateKey` and `ValidatePublicKey` helpers, using `ArgumentNullException.ThrowIfNull`, standardizing on `KeySize` for buffer sizes, marking the class `sealed`, and updating `Core` signature to accept nullable optional parameters (`Curve25519.NetCore/Curve25519.cs`).
- Implemented constant-time rejection of an all-zero shared secret per RFC 7748 using `CryptographicOperations.FixedTimeEquals`, and updated random key generation to use the `SecureRandom` v2 API (`CreateRandomPrivateKey`, `GetSharedSecret`).
- Updated `README.md` to document `.NET 8` support, the `SecureRandom` v2 dependency, and added security notes describing key validation and RFC guidance.

### Testing
- Installed and used the .NET 8 SDK (`dotnet --version` returned `8.0.x`) to validate tooling.
- Ran `dotnet restore` and `dotnet build -c Release` on the solution, and the solution built successfully with no errors.
- Executed the example with `dotnet run --project Curve25519.NetCore.Examples -c Release`, which printed `Shared secrets match: True` indicating correct interoperable key agreement behavior.
- Ran `dotnet list <project> package --outdated` to confirm package updates and found no further required updates for the project sources.