### PR TITLE
Add SIMD-accelerated 32-byte copy with scalar fallback

### DIFF
--- a/Curve25519.NetCore/Curve25519.cs
+++ b/Curve25519.NetCore/Curve25519.cs
@@ -14,6 +14,8 @@
  */
 
 using System;
+using System.Runtime.Intrinsics;
+using System.Runtime.InteropServices;
 using System.Security.Cryptography;
 
 namespace Curve25519.NetCore
@@ -219,7 +221,25 @@ namespace Curve25519.NetCore
 
         private void Copy32(byte[] source, byte[] destination)
         {
-            Array.Copy(source, 0, destination, 0, 32);
+            var sourceSpan = source.AsSpan(0, KeySize);
+            var destinationSpan = destination.AsSpan(0, KeySize);
+
+            if (Vector256.IsHardwareAccelerated)
+            {
+                MemoryMarshal.Cast<byte, Vector256<byte>>(destinationSpan)[0] = MemoryMarshal.Cast<byte, Vector256<byte>>(sourceSpan)[0];
+                return;
+            }
+
+            if (Vector128.IsHardwareAccelerated)
+            {
+                var sourceVectors = MemoryMarshal.Cast<byte, Vector128<byte>>(sourceSpan);
+                var destinationVectors = MemoryMarshal.Cast<byte, Vector128<byte>>(destinationSpan);
+                destinationVectors[0] = sourceVectors[0];
+                destinationVectors[1] = sourceVectors[1];
+                return;
+            }
+
+            sourceSpan.CopyTo(destinationSpan);
         }
 
         /* p[m..n+m-1] = q[m..n+m-1] + z * x */


### PR DESCRIPTION
### Motivation
- Improve hot-path performance for 32-byte copies used in core Curve25519 routines by leveraging CPU SIMD when available.
- Provide a safe fallback so behavior remains correct on platforms without SIMD support.

### Description
- Added `using System.Runtime.Intrinsics` and `using System.Runtime.InteropServices` to enable runtime vector intrinsics and memory casts.
- Replaced the previous `Array.Copy`-based `Copy32` with a SIMD-aware implementation that uses `Vector256<byte>` when `Vector256.IsHardwareAccelerated` is true.
- Added a fallback that uses two `Vector128<byte>` copies when 256-bit vectors are not available, and a scalar `Span.CopyTo` fallback when no vector acceleration exists.
- Implemented the copy using `Span` + `MemoryMarshal.Cast` to avoid allocations and to keep the change local and safe.

### Testing
- Installed .NET 8 SDK in the environment prior to running verification steps, which completed successfully.
- Restored and built the solution with `dotnet` as part of the test run, which completed successfully and produced the package artifact.
- Ran the test suite with `dotnet test Curve25519.NetCore.sln` and all automated tests passed (`Passed: 2, Failed: 0`).